### PR TITLE
Istio steps: do not patch the privileged SCC

### DIFF
--- a/istio/README.md
+++ b/istio/README.md
@@ -7,14 +7,12 @@
 `oc project myproject`  
 `oc adm policy add-scc-to-user anyuid  -z default`  
 `oc adm policy add-scc-to-user privileged -z default`  
-`oc patch scc/privileged --patch {\"allowedCapabilities\":[\"NET_ADMIN\"]}`  
 
 
 
 ## Install Istio Service Mesh
 `git clone https://github.com/istio/istio`   
 `cd istio && git checkout 3b31d818a1804e8d85e3396ed0f844c0893e2469`      
-`cd ..`    
 
 
 


### PR DESCRIPTION
The steps in the `README.md` for the istio example included a patch of the privileged SCC to set `NET_ADMIN` as the list of allowed capabilities.

This is not necessary, because the default privileged SCC already allows all caps. Moreover, it prevents apps to deploy, as they try to request `CAP_NET_ADMIN` (not `NET_ADMIN`).

Also there was an unneeded dir change that makes the rest of the relative paths fail.