### PR TITLE
Update probes in gitlab-runner.yaml

### DIFF
--- a/gitlab-ci-with-openshift/gitlab-runner.yaml
+++ b/gitlab-ci-with-openshift/gitlab-runner.yaml
@@ -154,7 +154,7 @@ objects:
             mountPath: /scripts
           livenessProbe:
             exec:
-              command: ["/usr/bin/pgrep","gitlab-ci-multi"]
+              command: ["/usr/bin/pgrep","gitlab-runner"]
             initialDelaySeconds: 60
             timeoutSeconds: 1
             periodSeconds: 10
@@ -162,7 +162,7 @@ objects:
             failureThreshold: 3
           readinessProbe:
             exec:
-              command: ["/usr/bin/pgrep","gitlab-ci-multi"]
+              command: ["/usr/bin/pgrep","gitlab-runner"]
             initialDelaySeconds: 10
             timeoutSeconds: 1
             periodSeconds: 10


### PR DESCRIPTION
Update liveness & readiness probes
the process name in the gitlab-runner docker image has changed. the process that gets spawned inside the container is now called gitlab-runner